### PR TITLE
Use rzCOBS encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Mathias Koch <mk@blackbird.online>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 readme = "README.md"
+resolver = "2"
 
 [dependencies]
 cortex-m = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ defmt-rtt = { version = "^0.2", optional = true }
 bbqueue = "0.4.10"
 nb = "*"
 crc = { version = "1.8.1", default-features = false }
-cobs = { version = "0.1.4", default-features = false }
+rzcobs = { version = "0.1.2", default-features = false }
+
+[dev-dependencies]
+rzcobs = { version = "0.1.2", features = ["std"] }
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,10 @@ static mut LOGPRODUCER: Option<LogProducer> = None;
 
 pub struct LogProducer {
     producer: Producer<'static, LogBufferSize>,
-    encoder: Option<(GrantW<'static, LogBufferSize>, rzcobs::Encoder<BufWriter<'static>>)>,
+    encoder: Option<(
+        GrantW<'static, LogBufferSize>,
+        rzcobs::Encoder<BufWriter<'static>>,
+    )>,
 }
 
 struct BufWriter<'a> {
@@ -57,10 +60,7 @@ struct BufWriter<'a> {
 
 impl<'a> BufWriter<'a> {
     pub fn new(buf: &'a mut [u8]) -> Self {
-        Self {
-            buf,
-            i: 0,
-        }
+        Self { buf, i: 0 }
     }
 }
 
@@ -69,7 +69,7 @@ impl<'a> rzcobs::Write for BufWriter<'a> {
 
     fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
         if self.i + 1 >= self.buf.len() {
-            return Err(())
+            return Err(());
         }
 
         self.buf[self.i] = byte;
@@ -106,7 +106,7 @@ impl LogProducer {
         if let Some((_, ref mut encoder)) = self.encoder {
             for b in bytes {
                 if let Err(e) = encoder.write(*b) {
-                    return Err(e)
+                    return Err(e);
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,7 @@ mod test {
             }
             let frame = rzcobs::decode(frame).unwrap();
 
-            compare_with_redundant_zeros_ignored(&frames[i], &frame);
+            compare_with_trailing_zeros_ignored(&frames[i], &frame);
             num_frames_read += 1;
         }
 
@@ -672,16 +672,14 @@ mod test {
         );
     }
 
-    // Since rzCOBS has a lossy property that it's not possible to know how many
-    // 0x00 bytes were compressed at the end of the frame, to simply compare
-    // two slices of bytes we'll find a middle ground w.r.t. number of trailing zeros and
-    // cut the two slices there to have an equal length slices.
-    //
     // From rzCOBS docs:
     //    When a message is encoded and then decoded, the result is the original message, with up
     //    to 6 zero bytes appended.
     //    Higher layer protocols must be able to deal with these appended zero bytes.
-    fn compare_with_redundant_zeros_ignored(left: &[u8], right: &[u8]) {
+    //
+    // Compares two slices of bytes by finding a middle ground w.r.t. number of trailing zeros
+    // and cuts the two slices there to have an equal length slices.
+    fn compare_with_trailing_zeros_ignored(left: &[u8], right: &[u8]) {
         let zeros_left = left.iter().rev().filter(|b| **b == 0x00).count();
         let zeros_right = right.iter().rev().filter(|b| **b == 0x00).count();
         let zeros_middle = core::cmp::min(zeros_left, zeros_right);


### PR DESCRIPTION
Obvious in a hindsight, but works perfectly fine with a `0xFF` as a sentinel byte.

Closes #12.
Related `defmt-persist-print` PR: https://github.com/eupn/defmt-persist-print/1.

P.S.: tested in hardware, works fine!