### PR TITLE
Implement page-based log rotation (wrapping)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,16 @@ resolver = "2"
 [dependencies]
 cortex-m = "0.6.3"
 embedded-hal = { version = "1.0.0-alpha.4" }
-embedded-storage = { git = "https://github.com/rust-embedded-community/embedded-storage" }
 defmt = { version = "^0.2.1" }
 defmt-rtt = { version = "^0.2", optional = true }
 bbqueue = "0.4.10"
 nb = "*"
 crc = { version = "1.8.1", default-features = false }
 rzcobs = { version = "0.1.2", default-features = false }
+
+[dependencies.embedded-storage]
+git = "https://github.com/eupn/embedded-storage"
+branch = "erasable-storage"
 
 [dev-dependencies]
 rzcobs = { version = "0.1.2", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ branch = "erasable-storage"
 
 [dev-dependencies]
 rzcobs = { version = "0.1.2", features = ["std"] }
+lazy_static = "1.4.0"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -894,17 +894,14 @@ mod test {
 
         let len = log.retrieve_frames(&mut storage, &mut read_data).unwrap();
 
-        let mut num_frames_read = 0;
-        for (i, frame) in read_data[..len]
+        for frame in read_data[..len]
             .split_mut(|b| *b == COBS_SENTINEL_BYTE)
             .filter(|f| f.len() >= 1)
-            .enumerate()
         {
             for b in frame.iter_mut() {
                 *b ^= 0xFF;
             }
-
-            let frame = rzcobs::decode(frame).unwrap();
+            rzcobs::decode(frame).unwrap();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(not(test), no_std)]
 
 pub use bbqueue::{consts, BBBuffer, ConstBBBuffer, Consumer, GrantW, Producer};
-use embedded_storage::Storage;
+use embedded_storage::{Storage, ErasableStorage};
 
 #[cfg(test)]
 pub mod pseudo_flash;
@@ -26,6 +26,7 @@ pub enum Error {
     StorageSize,
     StorageRead,
     StorageWrite,
+    StorageErase,
     BBBuffer,
 }
 
@@ -172,7 +173,7 @@ pub enum ReadMarker {
 
 impl<S> StorageHelper<S>
 where
-    S: Storage,
+    S: Storage + ErasableStorage,
 {
     const MAGIC_WORD: u64 = 0xFEED_BEEF_CAFE_BABE;
     const EMPTY: u64 = 0xFFFF_FFFF_FFFF_FFFF;
@@ -296,14 +297,14 @@ where
     }
 }
 
-pub struct LogManager<S: Storage> {
+pub struct LogManager<S: Storage + ErasableStorage> {
     inner: Consumer<'static, LogBufferSize>,
     pub(crate) helper: StorageHelper<S>,
 }
 
 impl<S> LogManager<S>
 where
-    S: Storage,
+    S: Storage + ErasableStorage,
 {
     /// Initialize a new LogManager.
     ///

--- a/src/pseudo_flash.rs
+++ b/src/pseudo_flash.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use embedded_storage::{ReadStorage, Storage};
+use embedded_storage::{ReadStorage, ErasableStorage, Storage};
 use std::collections::HashSet;
 
 #[derive(Default)]
@@ -44,6 +44,33 @@ impl<'a> Storage for PseudoFlashStorage<'a> {
     }
 }
 
+impl<'a> ErasableStorage for PseudoFlashStorage<'a> {
+    type Error = ();
+
+    const ERASE_SIZE: u32 = 128;
+
+    fn try_erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        if from % Self::ERASE_SIZE != 0 {
+            return Err(()) // Not aligned
+        }
+
+        if to >= self.capacity() as u32 {
+            return Err(()) // Overflow
+        }
+
+        for page_addr in (from..=to).step_by(Self::ERASE_SIZE as usize) {
+            let page_addr = page_addr as usize;
+            self.buf[page_addr..(page_addr + Self::ERASE_SIZE as usize)].fill(0xFF);
+
+            for wi in (page_addr..(page_addr + Self::ERASE_SIZE as usize)).step_by(8).map(|a| a / 8) {
+                self.word_set.remove(&wi);
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -59,13 +86,38 @@ mod test {
         };
 
         for wi in (0..STORAGE_CAPACITY).step_by(WORD_SIZE) {
-            storage.try_write(wi as u32, &[0xFF; WORD_SIZE]).unwrap();
+            storage.try_write(wi as u32, &[0x00; WORD_SIZE]).unwrap();
 
             // FLASH won't allow to write to the same programmed word twice before erasing
-            assert!(storage.try_write(wi as u32, &[0xFF; WORD_SIZE]).is_err());
+            assert!(storage.try_write(wi as u32, &[0x00; WORD_SIZE]).is_err());
         }
 
         // The code above should touch all of the storage words
         assert_eq!(storage.word_set.len(), STORAGE_CAPACITY / WORD_SIZE);
+    }
+
+    #[test]
+    fn can_write_after_erase() {
+        const NUM_PAGES: usize = 4;
+        const PAGE_SIZE: usize = PseudoFlashStorage::ERASE_SIZE as usize;
+        const STORAGE_CAPACITY: usize = PAGE_SIZE * NUM_PAGES;
+
+        let mut storage = PseudoFlashStorage {
+            buf: &mut [0xFFu8; STORAGE_CAPACITY],
+            ..Default::default()
+        };
+
+        for page_nr in (0..NUM_PAGES).into_iter() {
+            let from = (PAGE_SIZE * page_nr) as u32;
+            let to = (PAGE_SIZE * (page_nr + 1)) as u32;
+
+            storage.try_write(from, &[0x00; PAGE_SIZE]).unwrap();
+            assert!(storage.try_write(from, &[0x00; PAGE_SIZE]).is_err(), "can't write before erased");
+            assert!(storage.try_erase(from, to - 1).is_ok(), "can write after erase");
+            storage.try_write(from, &[0x00; PAGE_SIZE]).unwrap();
+            assert!(storage.try_write(from, &[0x00; PAGE_SIZE]).is_err(), "can't write before erased");
+
+            assert!(storage.try_erase(from + 1, to).is_err(), "can erase unaligned page");
+        }
     }
 }


### PR DESCRIPTION
Depends on #15.

As discussed in #13, this PR implements page-based circular storage.

Uses a modified version of `embedded-storage` crate that adds a single [`ErasableStorage`](https://github.com/eupn/embedded-storage/blob/0b016bc5d9bd5c17a416fa01f22c47d5bc9321d3/src/lib.rs#L50-L65) trait that has to be implemented for the used storage type.

Fixes #13 

P.S.: tested verified in hardware.
