### PR TITLE
test.yml: only build the lib part

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all --all-features --target thumbv7m-none-eabi
+          args: --lib --all-features --target thumbv7m-none-eabi
 
       - name: Test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
This PR makes the CI only build the lib with `no_std` target. This should avoid compilation failure due to tests using `std` directly or through dependencies.